### PR TITLE
QSP-6: Check values returned from pool functions

### DIFF
--- a/contracts/MetaPool.sol
+++ b/contracts/MetaPool.sol
@@ -337,7 +337,7 @@ contract MetaPool is IUniswapV3MintCallback, IUniswapV3SwapCallback, ERC20 {
         uint128(wideAmount0), // cast can't overflow
         uint128(wideAmount1) // cast can't overflow
       );
-      require(amount0Collected >= wideAmount0 || amount1Collected >= wideAmount1);
+      require(amount0Collected >= wideAmount0 && amount1Collected >= wideAmount1);
 
       // Can't overflow
       amount0 += amount0Collected;


### PR DESCRIPTION
All external calls to Uniswap either use the returned values, or document the reason why these values are not necessary to be used.