### PR TITLE
QSP-8: Lock compiler version pragma

### DIFF
--- a/contracts/ERC20.sol
+++ b/contracts/ERC20.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.7.0;
+pragma solidity 0.7.6;
 
 import './uniswap-v3/libraries/LowGasSafeMath.sol';
 

--- a/contracts/MetaPool.sol
+++ b/contracts/MetaPool.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.7.0;
+pragma solidity 0.7.6;
 
 import { IUniswapV3Pool } from "./uniswap-v3/interfaces/IUniswapV3Pool.sol";
 import { IUniswapV3Factory } from "./uniswap-v3/interfaces/IUniswapV3Factory.sol";

--- a/contracts/interfaces/IMetaPoolFactory.sol
+++ b/contracts/interfaces/IMetaPoolFactory.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.7.0;
+pragma solidity 0.7.6;
 
 interface IMetaPoolFactory {
   event PoolCreated(address indexed token0, address indexed token1, address pool);

--- a/contracts/libraries/LiquidityAmounts.sol
+++ b/contracts/libraries/LiquidityAmounts.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.5.0;
+pragma solidity 0.7.6;
 
 import '@uniswap/v3-core/contracts/libraries/FullMath.sol';
 import '@uniswap/v3-core/contracts/libraries/FixedPoint96.sol';

--- a/contracts/libraries/TransferHelper.sol
+++ b/contracts/libraries/TransferHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.6.0;
+pragma solidity 0.7.6;
 
 import '../uniswap-v3/interfaces/IERC20Minimal.sol';
 

--- a/contracts/libraries/UniMathHelpers.sol
+++ b/contracts/libraries/UniMathHelpers.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.7.0;
+pragma solidity 0.7.6;
 
 import '../uniswap-v3/libraries/FullMath.sol';
 import '../uniswap-v3/libraries/TickMath.sol';

--- a/contracts/mocks/MockERC20.sol
+++ b/contracts/mocks/MockERC20.sol
@@ -1,5 +1,5 @@
 //SPDX-License-Identifier: MIT
-pragma solidity ^0.7.0;
+pragma solidity 0.7.6;
 
 import "../ERC20.sol";
 

--- a/contracts/mocks/SwapTest.sol
+++ b/contracts/mocks/SwapTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity ^0.7.6;
+pragma solidity 0.7.6;
 
 import { IERC20Minimal } from "../uniswap-v3/interfaces/IERC20Minimal.sol";
 import { IUniswapV3SwapCallback } from "../uniswap-v3/interfaces/callback/IUniswapV3SwapCallback.sol";


### PR DESCRIPTION
All Solidity source files have been locked at version 0.7.6, the same Solidity version as Uniswap V3.